### PR TITLE
Close <i> tag before content section

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -8,6 +8,6 @@ layout: default
     </h2>
 </div>
 
-<i>This {{page.category}} {% if page.category != 'talk' %} workshop {% endif %} was given by {{page.author}} on {{page.date | date: "%B %-d, %Y" }} at {{page.subtitle}}. As {% if page.category != 'talk' %}taught{% else %}talked{% endif %}, it was {{page.length}} hours long.<i>
+<i>This {{page.category}} {% if page.category != 'talk' %} workshop {% endif %} was given by {{page.author}} on {{page.date | date: "%B %-d, %Y" }} at {{page.subtitle}}. As {% if page.category != 'talk' %}taught{% else %}talked{% endif %}, it was {{page.length}} hours long.</i>
 
 {{ content }}


### PR DESCRIPTION
I noticed that everything in the `{{ content }}` section of pages using `pages.html` was italicized. The culprit was an unclosed `<i>` tag.
